### PR TITLE
Add support for GNOME 47 in metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "name": "KMonad Toggle",
   "description": "Is your keyboard unusable for other people? Toggle it with one click!\n\nThis extension allows you to:\n • Toggle KMonad on or off with a quick setting\n • Autostart KMonad on login\n • Quickly check if KMonad is running from the top bar\n • Easily configure the KMonad launch command\n\nDo you miss any functionality in this extension? Feel free to open an issue on GitHub!\n\nNote: This extension does not manage the KMonad installation. See the installation guide and FAQ in the KMonad repo for instructions on how to set it up. https://github.com/kmonad/kmonad",
   "uuid": "kmonad-toggle@jurf.github.io",
-  "shell-version": ["45", "46"],
+  "shell-version": ["45", "46", "47"],
   "settings-schema": "org.gnome.shell.extensions.kmonad-toggle",
   "gettext-domain": "kmonad-toggle",
   "url": "https://github.com/jurf/gnome-kmonad-toggle",


### PR DESCRIPTION
Adding GNOME 47 to metadata.json was the only thing required to make the extension work on my end. I've been using it on GNOME 47 for a few weeks (since GNOME 47 was released basically). Let me know if more extensive tests/logs are required.

I took a quick look at the [Port Extensions to GNOME Shell 47](https://gjs.guide/extensions/upgrading/gnome-shell-47.html) and grepped the repo for the changes listed there. I did not see anything that seemed to require modifications in the extensions (I'm not used to extension development so I might have missed something).

Fixes #5.