### PR TITLE
Add GNOME 48 to metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "name": "KMonad Toggle",
   "description": "Is your keyboard unusable for other people? Toggle it with one click!\n\nThis extension allows you to:\n • Toggle KMonad on or off with a quick setting\n • Autostart KMonad on login\n • Quickly check if KMonad is running from the top bar\n • Easily configure the KMonad launch command\n\nDo you miss any functionality in this extension? Feel free to open an issue on GitHub!\n\nNote: This extension does not manage the KMonad installation. See the installation guide and FAQ in the KMonad repo for instructions on how to set it up. https://github.com/kmonad/kmonad",
   "uuid": "kmonad-toggle@jurf.github.io",
-  "shell-version": ["45", "46", "47"],
+  "shell-version": ["45", "46", "47", "48"],
   "settings-schema": "org.gnome.shell.extensions.kmonad-toggle",
   "gettext-domain": "kmonad-toggle",
   "url": "https://github.com/jurf/gnome-kmonad-toggle",


### PR DESCRIPTION
Very tiny PR to update to GNOME 48. I only added it to the metadata file.

No other changes are required from what I could find on https://gjs.guide/extensions/upgrading/gnome-shell-48.html.

Feel free to just close this PR and do the change yourself if that is simpler for you. I mostly wanted to report that I have been testing for ~ 1 week and everything is working OK.

Thanks!